### PR TITLE
move to latest release versions

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,24 +3,24 @@ import org.gradle.api.tasks.testing.logging.TestLogEvent.PASSED
 import org.gradle.api.tasks.testing.logging.TestLogEvent.SKIPPED
 
 object Properties {
-    const val kotlin_version = "1.3.60"
+    const val kotlin_version = "1.3.61"
     const val mustache_version = "0.9.6"
-    const val okhttp_version = "4.2.2"
+    const val okhttp_version = "4.3.0"
     const val gson_version = "2.8.6"
-    const val guava_version = "28.1-jre"
+    const val guava_version = "28.2-jre"
     const val system_rules_version = "1.19.0"
     const val truth_version = "1.0"
-    const val jupiter_version = "5.6.0-M1"
+    const val jupiter_version = "5.5.2"
     const val argparser_version = "2.0.7"
-    const val moshi_version = "1.9.1"
-    const val slf4j_version = "1.8.0-beta4"
+    const val moshi_version = "1.9.2"
+    const val slf4j_version = "1.7.30"
     const val json_path_version = "2.4.0"
     const val zt_exec_version = "1.11"
 }
 
 plugins {
     // Apply the Kotlin JVM plugin to add support for Kotlin.
-    id("org.jetbrains.kotlin.jvm") version "1.3.60"     // I would like to reference a const here but that doesn't work from the command line even tho intellij is ok with it
+    id("org.jetbrains.kotlin.jvm") version "1.3.61"     // I would like to reference a const here but that doesn't work from the command line even tho Intellij is OK with it
 
     // Apply the application plugin to add support for building a CLI application.
     application

--- a/src/main/resources/gradle.properties.mustache
+++ b/src/main/resources/gradle.properties.mustache
@@ -1,2 +1,2 @@
-kotlin_version = 1.3.60
+kotlin_version = 1.3.61
 

--- a/src/test/kotlin/com/pk/KtInitTests.kt
+++ b/src/test/kotlin/com/pk/KtInitTests.kt
@@ -23,7 +23,7 @@ class KtInitTests {
             overlays = buildOverlaysForSimpleProject(
                 inputs,
                 listOf(
-                    Dependency("compile", "com.google.guava", "guava", pinnedVersion = "28.1-jre"),
+                    Dependency("compile", "com.google.guava", "guava", pinnedVersion = "28.2-jre"),
                     Dependency("compile", "com.xenomachina", "kotlin-argparser"),
                     Dependency("testCompile", "com.google.truth", "truth"),
                     Dependency("testImplementation", "org.junit.jupiter", "junit-jupiter-engine"),
@@ -52,7 +52,7 @@ class KtInitTests {
             overlays = buildOverlaysForSimpleProject(
                 inputs,
                 listOf(
-                    Dependency("compile", "com.google.guava", "guava", pinnedVersion = "28.1-jre"),
+                    Dependency("compile", "com.google.guava", "guava", pinnedVersion = "28.2-jre"),
                     Dependency("testCompile", "com.google.truth", "truth"),
                     Dependency("testImplementation", "org.junit.jupiter", "junit-jupiter-engine"),
                     Dependency("testImplementation", "org.junit.jupiter", "junit-jupiter-api"),


### PR DESCRIPTION
SLF4J (1.8.0-beta4 -> 1.7.30) and JUnit (5.6.0-M1 -> 5.52) move back from alpha/beta/etc.